### PR TITLE
ci: Add GitHub Actions workflow for deploying notebook

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,8 +2,8 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    # branches: ["main"]
-    # tags: [v*]
+    branches: ["main"]
+    tags: [v*]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,67 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    # branches: ["main"]
+    # tags: [v*]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade --requirement requirements.lock
+          python -m pip install --upgrade notebook jupyterlab
+
+      - name: List installed Python packages
+        run: python -m pip list
+
+      - name: Execute and convert notebook
+        run: jupyter nbconvert --execute --to html --template lab --output index.html example.ipynb
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Setup build for deployment
+        run: |
+          mkdir -p _site
+          cp index.html _site
+
+      - name: Fix permissions
+        run: |
+          chmod -c -R +rX "_site/" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,10 +37,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --requirement requirements.lock
-          python -m pip install --upgrade notebook jupyterlab
+          python -m pip install --upgrade notebook jupyterlab jupytext
 
       - name: List installed Python packages
         run: python -m pip list
+
+      - name: Convert to ipynb form with jupytext
+        run: jupytext --to ipynb example.py
 
       - name: Execute and convert notebook
         run: jupyter nbconvert --execute --to html --template lab --output index.html example.ipynb


### PR DESCRIPTION
* Use jupyter nbconvert to execute the notebook and then convert it to HTML (which isn't perfect, but it is good enough for a first pass).
* Add GitHub Actions based workflow to deploy this HTML page to GitHub Pages as a website.