### PR TITLE
ci: Run GHA workflow on PRs and deploy only on main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -67,6 +67,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    needs: [build]
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
 
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,10 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
 
     runs-on: ubuntu-latest
 
@@ -65,6 +62,22 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+          with:
+            path: '_site'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main"]
     tags: [v*]
+  pull_request:
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -67,4 +68,5 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: actions/deploy-pages@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -82,5 +82,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: actions/deploy-pages@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -76,8 +76,8 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
-          with:
-            path: '_site'
+        with:
+          path: '_site'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
* Run GitHub Actions workflow on pull requests.
* Split workflow into build and deploy jobs.
* Only deploy the website if the triggering GitHub Action event is a push to main or a workflow dispatch event on main.